### PR TITLE
[operator] move controller to 🍋 alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.5.0 (**Not Released yet**)
+## v0.5.0 (**Not Released Yet**)
 
 This release contains enhancements and bug fixes.
 
@@ -10,7 +10,7 @@ This release contains enhancements and bug fixes.
 
 #### Bug Fixes:
 
-- None
+- [#139](https://github.com/blaqkube/mysql-operator/issues/139) Store check fails due to manager OCI filesystem cannot be accessed
 
 ## v0.4.0 (Jan 1, 2021)
 

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -49,6 +49,29 @@ export HTTP_PROXY=http://localhost:3128
 make run ENABLE_WEBHOOKS=false
 ```
 
+## Running the Operator in a Container 
+
+Assuming an OCI image for the controller has been created in the CI, you can test it
+instead of running the manager outside the cluster. To proceed:
+
+- Clone the project with `git clone https://github.com/blaqkube/mysql-operator`
+- Go into the operator subdirectory `cd mysql-operator/mysql-operator`
+- Install the CRDs to your default namespace `make install`
+- Set `IMG` with the version of the controller OCI that is expected
+- Run controllers in your cluster `make deploy`
+
+The script below does the steps above:
+
+```shell
+cd $(git rev-parse --show-toplevel)
+cd mysql-operator
+make install
+export IMG=quay.io/blaqkube/mysql-controller:$(\
+    git log --format='%H' -1 . | cut -c1-16)
+echo $IMG
+make deploy
+```
+
 ## kuttl for testing
 
 The project embeds kuttl tests. In order to run those tests, there are

--- a/mysql-operator/Dockerfile
+++ b/mysql-operator/Dockerfile
@@ -26,4 +26,4 @@ WORKDIR /app
 RUN chown 65532 /app
 COPY --from=builder /workspace/manager .
 
-ENTRYPOINT ["./manager"]
+ENTRYPOINT ["/app/manager"]

--- a/mysql-operator/Dockerfile
+++ b/mysql-operator/Dockerfile
@@ -18,7 +18,7 @@ COPY agent/ agent/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-FROM alpine:v3.13
+FROM alpine:3.13
 
 ARG agent_version=0
 ENV AGENT_VERSION=$agent_version

--- a/mysql-operator/Dockerfile
+++ b/mysql-operator/Dockerfile
@@ -19,12 +19,13 @@ COPY agent/ agent/
 RUN mkdir /app
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o /app/manager main.go
 
-FROM gcr.io/distroless/static:nonroot
+FROM alpine:3.13
 
 ARG agent_version=0
 ENV AGENT_VERSION=$agent_version
 
 WORKDIR /app
-COPY --from=builder --chown=65532 /app /app
+COPY --from=builder /app/manager .
+RUN chown -R 65532 /app
 
 ENTRYPOINT ["/app/manager"]

--- a/mysql-operator/Dockerfile
+++ b/mysql-operator/Dockerfile
@@ -18,14 +18,11 @@ COPY agent/ agent/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM alpine:v3.13
 
 ARG agent_version=0
 ENV AGENT_VERSION=$agent_version
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["./manager"]

--- a/mysql-operator/Dockerfile
+++ b/mysql-operator/Dockerfile
@@ -22,7 +22,8 @@ FROM alpine:3.13
 
 ARG agent_version=0
 ENV AGENT_VERSION=$agent_version
-WORKDIR /
+WORKDIR /app
+RUN chown 65532 /app
 COPY --from=builder /workspace/manager .
 
 ENTRYPOINT ["./manager"]

--- a/mysql-operator/Dockerfile
+++ b/mysql-operator/Dockerfile
@@ -25,6 +25,6 @@ ARG agent_version=0
 ENV AGENT_VERSION=$agent_version
 
 WORKDIR /app
-COPY --from=builder --chown=nonroot:nonroot /app /app
+COPY --from=builder --chown=65532 /app /app
 
 ENTRYPOINT ["/app/manager"]

--- a/mysql-operator/Dockerfile
+++ b/mysql-operator/Dockerfile
@@ -16,14 +16,15 @@ COPY controllers/ controllers/
 COPY agent/ agent/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN mkdir /app
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o /app/manager main.go
 
-FROM alpine:3.13
+FROM gcr.io/distroless/static:nonroot
 
 ARG agent_version=0
 ENV AGENT_VERSION=$agent_version
+
 WORKDIR /app
-RUN chown 65532 /app
-COPY --from=builder /workspace/manager .
+COPY --from=builder --chown=nonroot:nonroot /app /app
 
 ENTRYPOINT ["/app/manager"]

--- a/mysql-operator/bundle/manifests/mysql-operator.clusterserviceversion.yaml
+++ b/mysql-operator/bundle/manifests/mysql-operator.clusterserviceversion.yaml
@@ -373,7 +373,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 command:
-                - /manager
+                - /app/manager
                 image: quay.io/blaqkube/mysql-controller:0.4.0
                 livenessProbe:
                   httpGet:

--- a/mysql-operator/bundle/manifests/mysql.blaqkube.io_backups.yaml
+++ b/mysql-operator/bundle/manifests/mysql.blaqkube.io_backups.yaml
@@ -14,7 +14,16 @@ spec:
     singular: backup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Backup ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Backup phase
+      jsonPath: .status.reason
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Backup is the Schema for the backups API

--- a/mysql-operator/bundle/manifests/mysql.blaqkube.io_databases.yaml
+++ b/mysql-operator/bundle/manifests/mysql.blaqkube.io_databases.yaml
@@ -14,7 +14,16 @@ spec:
     singular: database
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Database ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Database phase
+      jsonPath: .status.reason
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Database is the Schema for the databases API

--- a/mysql-operator/bundle/manifests/mysql.blaqkube.io_grants.yaml
+++ b/mysql-operator/bundle/manifests/mysql.blaqkube.io_grants.yaml
@@ -14,7 +14,16 @@ spec:
     singular: grant
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Grant ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Grant phase
+      jsonPath: .status.reason
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Grant is the Schema for the grants API

--- a/mysql-operator/bundle/manifests/mysql.blaqkube.io_instances.yaml
+++ b/mysql-operator/bundle/manifests/mysql.blaqkube.io_instances.yaml
@@ -14,7 +14,16 @@ spec:
     singular: instance
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Instance ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Instance phase
+      jsonPath: .status.reason
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Instance is the Schema for the instances API

--- a/mysql-operator/bundle/manifests/mysql.blaqkube.io_stores.yaml
+++ b/mysql-operator/bundle/manifests/mysql.blaqkube.io_stores.yaml
@@ -14,7 +14,16 @@ spec:
     singular: store
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Store ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Store phase
+      jsonPath: .status.reason
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Store is the Schema for the stores API

--- a/mysql-operator/bundle/manifests/mysql.blaqkube.io_users.yaml
+++ b/mysql-operator/bundle/manifests/mysql.blaqkube.io_users.yaml
@@ -14,7 +14,16 @@ spec:
     singular: user
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: User ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: User phase
+      jsonPath: .status.reason
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: User is the Schema for the users API

--- a/mysql-operator/config/manager/manager.yaml
+++ b/mysql-operator/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65532
       containers:
       - command:
-        - /manager
+        - /app/manager
         args:
         - --leader-elect
         image: controller:latest


### PR DESCRIPTION
## Purpose
Fixes issue #139 .

## Approach
Move the manager to `alpine:v3.13`. This might not be the best choice possible, however we need to be able to share files with buckets to validate it is working. It could be that moving files to a separate directory can ally to keep the distroless OCI. We would have to perform some more digging.

#### Open Questions and Pre-Merge TODOs
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have added the reference to the `CHANGELOG.md` file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have run the e2e tests in `mysql-operator/tests` with success



