### PR TITLE
[operator] improve 🗨 logs for the operator

### DIFF
--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -46,7 +46,7 @@ make install
 kubectl apply -f .ci/squid.yaml
 kubectl port-forward squid 3128 &
 export http_proxy=http://localhost:3128
-make run ENABLE_WEBHOOKS=false
+make run ARGS="--zap-encoder=console" ENABLE_WEBHOOKS=false
 ```
 
 ## Running the Operator in a Container 
@@ -99,7 +99,7 @@ make install
 kubectl apply -f .ci/squid.yaml
 kubectl port-forward squid 3128 &
 export http_proxy=http://localhost:3128
-make run ENABLE_WEBHOOKS=false
+make run ARGS="--zap-encoder=console" ENABLE_WEBHOOKS=false
 ```
 
 Running `kuttl` tests should be as simple as 
@@ -148,7 +148,7 @@ make install
 kubectl apply -f .ci/squid.yaml
 kubectl port-forward squid 3128 &
 export http_proxy=http://localhost:3128
-make run ENABLE_WEBHOOKS=false
+make run ARGS="--zap-encoder=console" ENABLE_WEBHOOKS=false
 ```
 
 Running the test should then be as easy as running:

--- a/docs/developers/welcome.md
+++ b/docs/developers/welcome.md
@@ -61,7 +61,7 @@ To run it from outside of the cluster, for development purpose:
 - Install the CRDs to your default namespace `make install`
 - Make sure you have installed an HTTP proxy as described in the previous
   section `export http_proxy=http://localhost:3128`
-- Run controllers outside of your cluster `make run ENABLE_WEBHOOKS=false`
+- Run controllers outside of your cluster `make run ENABLE_WEBHOOKS=false ARGS="--zap-encoder=console"`
 
 The operator should start. Once done, you can create a MySQL instance with a
 manifest like the one below; run `kubectl apply -f blue-instance.yaml` to

--- a/mysql-operator/Makefile
+++ b/mysql-operator/Makefile
@@ -42,7 +42,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	go run ./main.go $(ARGS)
 
 # Install CRDs into a cluster
 install: manifests kustomize


### PR DESCRIPTION
## Purpose
Improve operator logging

## Approach
_How does this change address the problem?_

Changes include _(add your own list)_:
- [ ] ...

#### Open Questions and Pre-Merge TODOs
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have added the reference to the `CHANGELOG.md` file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have run the e2e tests in `mysql-operator/tests` with success

#### Learning
Kubebuilder comes with a logr compatible interface that can be changed, as described in [Building Operator > Logging](https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/)
