### PR TITLE
[operator] Monitor 💚 controller-manager from 💜 Prometheus

### DIFF
--- a/mysql-operator/config/default/kustomization.yaml
+++ b/mysql-operator/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
@@ -44,7 +44,7 @@ patchesStrategicMerge:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
+#vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 #- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:


### PR DESCRIPTION
## Purpose
Add support for Prometheus probes in the controller manager.

## Approach
As a matter of fact, controller-runtime supports prometheus probes. The question is kind of how do we expose them and what should we add

#### Note
**WE DO NOT WANT TO CREATE A HARD DEPENDENCY TO PROMETHEUS OR PROMETHEUS OPERATOR**

Changes include _(add your own list)_:
- [ ] ...

#### Open Questions and Pre-Merge TODOs
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have added the reference to the `CHANGELOG.md` file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have run the e2e tests in `mysql-operator/tests` with success

#### Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
